### PR TITLE
Data decorator

### DIFF
--- a/oandapyV20/endpoints/accounts.py
+++ b/oandapyV20/endpoints/accounts.py
@@ -1,6 +1,6 @@
 """Handle account endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass, params
+from .decorators import dyndoc_insert, endpoint, abstractclass, extendargs
 
 # responses serve both testing purpose aswell as dynamic docstring replacement
 responses = {
@@ -303,7 +303,7 @@ class Accounts(APIRequest):
     METHOD = "GET"
 
     @dyndoc_insert(responses)
-    def __init__(self, accountID=None, data=None):
+    def __init__(self, accountID=None):
         """Instantiate an Accounts APIRequest instance.
 
         Parameters
@@ -385,7 +385,7 @@ class Accounts(APIRequest):
 
         """
         endpoint = self.ENDPOINT.format(accountID=accountID)
-        super(Accounts, self).__init__(endpoint, method=self.METHOD, body=data)
+        super(Accounts, self).__init__(endpoint, method=self.METHOD)
 
 
 @endpoint("v3/accounts")
@@ -411,7 +411,7 @@ class AccountSummary(Accounts):
     """
 
 
-@params
+@extendargs("params")
 @endpoint("v3/accounts/{accountID}/instruments")
 class AccountInstruments(Accounts):
     """AccountInstruments.
@@ -423,6 +423,7 @@ class AccountInstruments(Accounts):
     """
 
 
+@extendargs("data")
 @endpoint("v3/accounts/{accountID}/configuration", "PATCH")
 class AccountConfiguration(Accounts):
     """AccountConfiguration.
@@ -431,7 +432,7 @@ class AccountConfiguration(Accounts):
     """
 
 
-@params
+@extendargs("params")
 @endpoint("v3/accounts/{accountID}/changes")
 class AccountChanges(Accounts):
     """AccountChanges.

--- a/oandapyV20/endpoints/apirequest.py
+++ b/oandapyV20/endpoints/apirequest.py
@@ -8,7 +8,7 @@ class APIRequest(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def __init__(self, endpoint, method="GET", body=None):
+    def __init__(self, endpoint, method="GET"):
         """Instantiate an API request.
 
         Parameters
@@ -27,7 +27,6 @@ class APIRequest(object):
 
         self._endpoint = endpoint
         self.method = method
-        self.body = body
 
     def response(self, s):
         """response - set the response of the request."""

--- a/oandapyV20/endpoints/decorators.py
+++ b/oandapyV20/endpoints/decorators.py
@@ -80,19 +80,25 @@ def abstractclass(cls):
     return cls
 
 
-def params(cls):
-    """'params' decorator.
+class extendargs(object):
+    """'extendargs' decorator.
 
-    Add the 'params' argument to the constructor of the class.
+    Add extra arguments to the argumentlist of the constructor of the class.
     """
-    # save parent class __init__
-    origInit = cls.__bases__[0].__dict__["__init__"]
 
-    def wrapInit(self, *args, **kwargs):
-        if "params" in kwargs:
-            setattr(cls, "params", kwargs['params'])
-            del kwargs['params']
-        origInit(self, *args, **kwargs)
-    setattr(cls, "__init__", wrapInit)
+    def __init__(self, *loa):
+        self.loa = loa
 
-    return cls
+    def __call__(self, cls):
+        # save parent class __init__
+        origInit = cls.__bases__[0].__dict__["__init__"]
+
+        def wrapInit(wself, *args, **kwargs):
+            for extraArg in self.loa:
+                if extraArg in kwargs:
+                    setattr(cls, extraArg, kwargs[extraArg])
+                    del kwargs[extraArg]
+            origInit(wself, *args, **kwargs)
+        setattr(cls, "__init__", wrapInit)
+
+        return cls

--- a/oandapyV20/endpoints/orders.py
+++ b/oandapyV20/endpoints/orders.py
@@ -1,6 +1,6 @@
 """Handle orders and pendingOrders endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass, params
+from .decorators import dyndoc_insert, endpoint, abstractclass, extendargs
 
 # responses serve both testing purpose aswell as dynamic docstring replacement
 responses = {
@@ -62,7 +62,7 @@ class Orders(APIRequest):
     METHOD = "GET"
 
     @dyndoc_insert(responses)
-    def __init__(self, accountID, orderID=None, data=None):
+    def __init__(self, accountID, orderID=None):
         """Instantiate an Orders request.
 
         Parameters
@@ -82,9 +82,10 @@ class Orders(APIRequest):
             endpoints.
         """
         endpoint = self.ENDPOINT.format(accountID=accountID, orderID=orderID)
-        super(Orders, self).__init__(endpoint, method=self.METHOD, body=data)
+        super(Orders, self).__init__(endpoint, method=self.METHOD)
 
 
+@extendargs("data")
 @endpoint("v3/accounts/{accountID}/orders", "POST")
 class OrderCreate(Orders):
     """OrderCreate.
@@ -93,7 +94,7 @@ class OrderCreate(Orders):
     """
 
 
-@params
+@extendargs("params")
 @endpoint("v3/accounts/{accountID}/orders")
 class OrderList(Orders):
     """OrderList.
@@ -118,6 +119,7 @@ class OrderDetails(Orders):
     """
 
 
+@extendargs("data")
 @endpoint("v3/accounts/{accountID}/orders/{orderID}", "PUT")
 class OrderReplace(Orders):
     """OrderReplace.
@@ -135,6 +137,7 @@ class OrderCancel(Orders):
     """
 
 
+@extendargs("data")
 @endpoint("v3/accounts/{accountID}/orders/{orderID}/clientExtensions", "PUT")
 class OrderClientExtensions(Orders):
     """OrderClientExtensions.

--- a/oandapyV20/endpoints/positions.py
+++ b/oandapyV20/endpoints/positions.py
@@ -1,6 +1,6 @@
 """Handle position endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass
+from .decorators import dyndoc_insert, endpoint, abstractclass, extendargs
 
 responses = {
     "_v3_accounts_accountID_positions": {
@@ -81,7 +81,7 @@ class Positions(APIRequest):
     METHOD = "GET"
 
     @dyndoc_insert(responses)
-    def __init__(self, accountID, instrument=None, data=None):
+    def __init__(self, accountID, instrument=None):
         """Instantiate a Positions APIRequest instance.
 
         Parameters
@@ -99,7 +99,7 @@ class Positions(APIRequest):
         endpoint = self.ENDPOINT.format(accountID=accountID,
                                         instrument=instrument)
         super(Positions, self).__init__(endpoint,
-                                        method=self.METHOD, body=data)
+                                        method=self.METHOD)
 
 
 @endpoint("v3/accounts/{accountID}/positions")
@@ -129,6 +129,7 @@ class PositionDetails(Positions):
     """
 
 
+@extendargs("data")
 @endpoint("v3/accounts/{accountID}/positions/{instrument}/close", "PUT")
 class PositionClose(Positions):
     """PositionClose.

--- a/oandapyV20/endpoints/pricing.py
+++ b/oandapyV20/endpoints/pricing.py
@@ -1,6 +1,6 @@
 """Handle pricing endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass, params
+from .decorators import dyndoc_insert, endpoint, abstractclass, extendargs
 
 responses = {
     "_v3_accounts_accountID_pricing": {
@@ -151,7 +151,7 @@ class Pricing(APIRequest):
         super(Pricing, self).__init__(endpoint, method=self.METHOD)
 
 
-@params
+@extendargs("params")
 @endpoint("v3/accounts/{accountID}/pricing")
 class PricingInfo(Pricing):
     """Pricing.

--- a/oandapyV20/endpoints/trades.py
+++ b/oandapyV20/endpoints/trades.py
@@ -1,6 +1,6 @@
 """Handle trades endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass, params
+from .decorators import dyndoc_insert, endpoint, abstractclass, extendargs
 
 responses = {
     "_v3_accounts_accountID_trades": {
@@ -46,7 +46,7 @@ class Trades(APIRequest):
     METHOD = "GET"
 
     @dyndoc_insert(responses)
-    def __init__(self, accountID, tradeID=None, data=None):
+    def __init__(self, accountID, tradeID=None):
         """Instantiate a Trades APIRequest instance.
 
         Parameters
@@ -66,10 +66,10 @@ class Trades(APIRequest):
             endpoints.
         """
         endpoint = self.ENDPOINT.format(accountID=accountID, tradeID=tradeID)
-        super(Trades, self).__init__(endpoint, method=self.METHOD, body=data)
+        super(Trades, self).__init__(endpoint, method=self.METHOD)
 
 
-@params
+@extendargs("params")
 @endpoint("v3/accounts/{accountID}/trades")
 class TradesList(Trades):
     """TradesList.
@@ -94,6 +94,7 @@ class TradeDetails(Trades):
     """
 
 
+@extendargs("data")
 @endpoint("v3/accounts/{accountID}/trades/{tradeID}/close", "PUT")
 class TradeClose(Trades):
     """TradeClose.
@@ -102,6 +103,7 @@ class TradeClose(Trades):
     """
 
 
+@extendargs("data")
 @endpoint("v3/accounts/{accountID}/trades/{tradeID}/clientExtensions", "PUT")
 class TradeClientExtensions(Trades):
     """TradeClientExtensions.
@@ -111,6 +113,7 @@ class TradeClientExtensions(Trades):
     """
 
 
+@extendargs("data")
 @endpoint("v3/accounts/{accountID}/trades/{tradeID}/orders", "PUT")
 class TradeCRCDO(Trades):
     """TradeCRCDO.

--- a/oandapyV20/endpoints/transactions.py
+++ b/oandapyV20/endpoints/transactions.py
@@ -1,6 +1,6 @@
 """Handle transactions endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass, params
+from .decorators import dyndoc_insert, endpoint, abstractclass, extendargs
 
 responses = {
     "_v3_accounts_accountID_transactions": {
@@ -88,10 +88,10 @@ class Transactions(APIRequest):
         endpoint = self.ENDPOINT.format(accountID=accountID,
                                         transactionID=transactionID)
         super(Transactions, self).__init__(endpoint,
-                                           method=self.METHOD, body=None)
+                                           method=self.METHOD)
 
 
-@params
+@extendargs("params")
 @endpoint("v3/accounts/{accountID}/transactions")
 class TransactionList(Transactions):
     """TransactionList.
@@ -109,7 +109,7 @@ class TransactionDetails(Transactions):
     """
 
 
-@params
+@extendargs("params")
 @endpoint("v3/accounts/{accountID}/transactions/idrange")
 class TransactionIDRange(Transactions):
     """TransactionIDRange.
@@ -118,7 +118,7 @@ class TransactionIDRange(Transactions):
     """
 
 
-@params
+@extendargs("params")
 @endpoint("v3/accounts/{accountID}/transactions/sinceid")
 class TransactionSinceID(Transactions):
     """TransactionSinceID.

--- a/oandapyV20/oandapyV20.py
+++ b/oandapyV20/oandapyV20.py
@@ -200,8 +200,8 @@ class API(object):
         request_args = {}
         if method == 'get':
             request_args['params'] = params
-        elif endpoint.body:
-            request_args['data'] = json.dumps(endpoint.body)
+        elif hasattr(endpoint, "data") and endpoint.data:
+            request_args['data'] = json.dumps(endpoint.data)
 
         response = None
         try:

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -116,6 +116,20 @@ class TestAccounts(unittest.TestCase):
         s_result = json.dumps(result)
         self.assertTrue("DE30_EUR" in s_result and "EUR_AUD" not in s_result)
 
+    def test__get_instruments_data_exception(self):
+        """check for data parameter exception."""
+        with self.assertRaises(TypeError) as oErr:
+            r = accounts.AccountInstruments(accountID=accountID, data={})
+
+        self.assertEqual("__init__() got an unexpected keyword argument 'data'", "{}".format(oErr.exception))
+
+    def test__get_instruments_params_exception(self):
+        """check for params parameter exception."""
+        with self.assertRaises(TypeError) as oErr:
+            r = accounts.AccountConfiguration(accountID=accountID, params={})
+
+        self.assertEqual("__init__() got an unexpected keyword argument 'params'", "{}".format(oErr.exception))
+
 if __name__ == "__main__":
 
     unittest.main()

--- a/tests/test_oandapyv20.py
+++ b/tests/test_oandapyv20.py
@@ -51,6 +51,19 @@ class TestOandapyV20(unittest.TestCase):
 
         self.assertTrue("Unknown environment" in "{}".format(envErr.exception))
 
+    def test__requests_exception(self):
+        """force a requests exception."""
+        from requests.exceptions import RequestException
+        import oandapyV20.endpoints.accounts as accounts
+        text = "No connection " \
+               "adapters were found for 'ttps://test.com/v3/accounts'"
+        api.api_url = "ttps://test.com"
+        r = accounts.AccountList()
+        with self.assertRaises(RequestException) as oErr:
+            result = api.request(r)
+
+        self.assertEqual("{}".format(oErr.exception), text)
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Consistent use of 'data' versus the mix of 'body' / 'data' meaning the same thing

- decorator changes: @params to @extendargs
- endpoint modified for new decorators
- oandapyV20 client modified 
- tests added