### PR TITLE
Request status

### DIFF
--- a/oandapyV20/endpoints/apirequest.py
+++ b/oandapyV20/endpoints/apirequest.py
@@ -8,7 +8,7 @@ class APIRequest(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def __init__(self, endpoint, method="GET"):
+    def __init__(self, endpoint, method="GET", expected_status=200):
         """Instantiate an API request.
 
         Parameters
@@ -23,10 +23,22 @@ class APIRequest(object):
             dictionary with data for the request. This data
             will be sent as JSON-data.
         """
+        self._expected_status = expected_status
+        self._status_code = None
         self._response = None
 
         self._endpoint = endpoint
         self.method = method
+
+    @property
+    def status_code(self):
+        return self._status_code
+
+    @status_code.setter
+    def status_code(self, value):
+        if value != self._expected_status:
+            raise ValueError("{} {} {:d}".format(self, self.method, value))
+        self._status_code = value
 
     def response(self, s):
         """response - set the response of the request."""

--- a/oandapyV20/endpoints/decorators.py
+++ b/oandapyV20/endpoints/decorators.py
@@ -29,7 +29,7 @@ def dyndoc_insert(src):
     return dec
 
 
-def endpoint(url, method="GET"):
+def endpoint(url, method="GET", expected_status=200):
     """endpoint - decorator to manipulate the REST-service endpoint.
 
     The endpoint decorator sets the endpoint and the method for the class
@@ -38,6 +38,7 @@ def endpoint(url, method="GET"):
     def dec(obj):
         obj.ENDPOINT = url
         obj.METHOD = method
+        obj.EXPECTED_STATUS = expected_status
         return obj
 
     return dec

--- a/oandapyV20/endpoints/orders.py
+++ b/oandapyV20/endpoints/orders.py
@@ -60,6 +60,7 @@ class Orders(APIRequest):
 
     ENDPOINT = ""
     METHOD = "GET"
+    EXPECTED_STATUS = 0
 
     @dyndoc_insert(responses)
     def __init__(self, accountID, orderID=None):
@@ -82,11 +83,12 @@ class Orders(APIRequest):
             endpoints.
         """
         endpoint = self.ENDPOINT.format(accountID=accountID, orderID=orderID)
-        super(Orders, self).__init__(endpoint, method=self.METHOD)
+        super(Orders, self).__init__(endpoint, method=self.METHOD,
+                                     expected_status=self.EXPECTED_STATUS)
 
 
 @extendargs("data")
-@endpoint("v3/accounts/{accountID}/orders", "POST")
+@endpoint("v3/accounts/{accountID}/orders", "POST", 201)
 class OrderCreate(Orders):
     """OrderCreate.
 
@@ -120,7 +122,7 @@ class OrderDetails(Orders):
 
 
 @extendargs("data")
-@endpoint("v3/accounts/{accountID}/orders/{orderID}", "PUT")
+@endpoint("v3/accounts/{accountID}/orders/{orderID}", "PUT", 201)
 class OrderReplace(Orders):
     """OrderReplace.
 

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -124,7 +124,8 @@ class TestOrders(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             result = api.request(r)
 
-        self.assertTrue("200" in "{}".format(err.exception))
+        self.assertTrue("200" in "{}".format(err.exception) and
+                        r.status_code is None)
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Handling of request status added. Most endpoints return 200 as HTTP-status in case of succes. Some return 201. Code has been modified to handle the expected status as a request property instead of the assumption that 200 is OK.