### PR TITLE
allow using request parameters

### DIFF
--- a/oandapyV20/oandapyV20.py
+++ b/oandapyV20/oandapyV20.py
@@ -148,7 +148,8 @@ class API(object):
         }
     """
 
-    def __init__(self, access_token, environment="practice", headers=None):
+    def __init__(self, access_token, environment="practice",
+                 headers=None, request_params={}):
         """Instantiate an instance of OandaPy's API wrapper.
 
         Parameters
@@ -165,6 +166,14 @@ class API(object):
             endpoints need data in a JSON format. These calls require the
             header: 'Content-Type: application/json'.
 
+        request_params : (optional)
+            parameters to be passed to the request. This can be used to apply
+            for instance a timeout value:
+
+               request_params={"timeout": 0.1}
+
+            See specs of the requests module for full details of possible
+            parameters.
         """
         try:
             TRADING_ENVIRONMENTS[environment]
@@ -177,6 +186,7 @@ class API(object):
         self.client = requests.Session()
         self._connected = False
         self.client.stream = False
+        self._request_params = request_params
 
         # personal token authentication
         if self.access_token:
@@ -190,6 +200,10 @@ class API(object):
     def connected(self):
         return self._connected
 
+    @property
+    def request_params(self):
+        return self._request_params
+
     def disconnect(self):
         """disconnect.
 
@@ -198,17 +212,24 @@ class API(object):
         """
         self._connected = False
 
-    def __request(self, method, url, request_args):
+    def __request(self, method, url, request_args, stream=False):
+        """__request.
+
+        make the actual request. This method is called by the
+        request method in case of 'regular' API-calls. Or indirectly by
+        the__stream_request method if it concerns a 'streaming' call.
+        """
         func = getattr(self.client, method)
 
         response = None
         try:
-            response = func(url, **request_args)
+            response = func(url, stream=stream, **request_args)
         except requests.RequestException as e:
             # log it ?
             raise e
         else:
-            self._connected = True
+            if stream:
+                self._connected = True
 
         # Handle error responses
         if response.status_code >= 400:
@@ -217,13 +238,13 @@ class API(object):
         return response
 
     def __stream_request(self, method, url, request_args):
-        """_stream_request.
+        """__stream_request.
 
         make a 'stream' request. This method is called by
         the 'request' method after it has determined which
         call applies: regular or streaming.
         """
-        response = self.__request(method, url, request_args)
+        response = self.__request(method, url, request_args, stream=True)
         lines = response.iter_lines(ITER_LINES_CHUNKSIZE)
         for line in lines:
             if not self.connected:
@@ -247,7 +268,6 @@ class API(object):
         ------
             V20Error in case of HTTP response code >= 400
         """
-
         method = endpoint.method
         method = method.lower()
         params = None
@@ -263,12 +283,15 @@ class API(object):
         elif hasattr(endpoint, "data") and endpoint.data:
             request_args['data'] = json.dumps(endpoint.data)
 
+        # if any parameter for request then merge them
+        request_args.update(self._request_params)
+
         # which API to access ?
-        at = "api"
         if not (hasattr(endpoint, "STREAM") and
                 getattr(endpoint, "STREAM") is True):
-            url = "{}/{}".format(TRADING_ENVIRONMENTS[self.environment][at],
-                                 endpoint)
+            url = "{}/{}".format(
+                            TRADING_ENVIRONMENTS[self.environment]["api"],
+                            endpoint)
 
             response = self.__request(method, url, request_args)
             content = response.content.decode('utf-8')
@@ -281,8 +304,7 @@ class API(object):
             return content
 
         else:
-            at = "stream"
-            self.client.stream = True
-            url = "{}/{}".format(TRADING_ENVIRONMENTS[self.environment][at],
-                                 endpoint)
+            url = "{}/{}".format(
+                            TRADING_ENVIRONMENTS[self.environment]["stream"],
+                            endpoint)
             return self.__stream_request(method, url, request_args)

--- a/tests/test_oandapyv20.py
+++ b/tests/test_oandapyv20.py
@@ -57,6 +57,15 @@ class TestOandapyV20(unittest.TestCase):
 
         self.assertTrue("Unknown environment" in "{}".format(envErr.exception))
 
+    def test__requests_params(self):
+        """request parameters."""
+        request_params = {"timeout": 10}
+        api = API(environment=environment,
+                  access_token=access_token,
+                  headers={"Content-Type": "application/json"},
+                  request_params=request_params)
+        self.assertTrue(api.request_params == request_params)
+
     def test__requests_exception(self):
         """force a requests exception."""
         from requests.exceptions import RequestException


### PR DESCRIPTION
The requests package supports a number of parameters. A timeout parameter can now be passed for instance.
```python
request_params = {"timeout" : 1.0}
api = API(access_token=access_token,
          environment="practice",
          request_params=request_params)
