### PR TITLE
made API-class (client) stateless

### DIFF
--- a/examples/streaming_prices.py
+++ b/examples/streaming_prices.py
@@ -3,7 +3,7 @@
 import argparse
 import json
 from oandapyV20 import API
-from oandapyV20.exceptions import V20Error
+from oandapyV20.exceptions import V20Error, StreamTerminated
 from oandapyV20.endpoints.pricing import PricingStream
 from exampleauth import exampleAuth
 from requests.exceptions import ConnectionError
@@ -48,19 +48,21 @@ while True:
             print R
             n += 1
             if MAXREC and n >= MAXREC:
-                api.disconnect()
+                r.terminate("maxrecs received: {}".format(MAXREC))
 
     except V20Error as e:
+        # catch API related errors that may occur
         with open("LOG", "a") as LOG:
             LOG.write("V20Error: {}\n".format(e))
+        break
     except ConnectionError as e:
         with open("LOG", "a") as LOG:
             LOG.write("Error: {}\n".format(e))
+    except StreamTerminated as e:
+        with open("LOG", "a") as LOG:
+            LOG.write("Stopping: {}\n".format(e))
+        break
     except Exception as e:
         with open("LOG", "a") as LOG:
             LOG.write("??? : {}\n".format(e))
-            break
-    else:
-        if not api.connected:
-            print("Stopping")
-            break
+        break

--- a/oandapyV20/endpoints/apirequest.py
+++ b/oandapyV20/endpoints/apirequest.py
@@ -40,9 +40,15 @@ class APIRequest(object):
             raise ValueError("{} {} {:d}".format(self, self.method, value))
         self._status_code = value
 
-    def response(self, s):
+    @property
+    def response(self):
+        """response - get the response of the request."""
+        return self._response
+
+    @response.setter
+    def response(self, value):
         """response - set the response of the request."""
-        self._response = s
+        self._response = value
 
     def __str__(self):
         """return the endpoint."""

--- a/oandapyV20/endpoints/pricing.py
+++ b/oandapyV20/endpoints/pricing.py
@@ -1,8 +1,10 @@
 # -*- encoding: utf-8 -*-
 """Handle pricing endpoints."""
 from .apirequest import APIRequest
+from ..exceptions import StreamTerminated
 from .decorators import dyndoc_insert, endpoint, abstractclass, extendargs
 from .definitions.pricing import definitions    # flake8: noqa
+from types import GeneratorType
 
 responses = {
     "_v3_accounts_accountID_pricing": {
@@ -172,3 +174,9 @@ class PricingStream(Pricing):
     """
 
     STREAM = True
+
+    def terminate(self, message=""):
+        if not isinstance(self.response, GeneratorType):
+            raise ValueError("request does not contain a stream response")
+
+        self.response.throw(StreamTerminated(message))

--- a/oandapyV20/endpoints/transactions.py
+++ b/oandapyV20/endpoints/transactions.py
@@ -1,8 +1,10 @@
 # -*- encoding: utf-8 -*-
 """Handle transactions endpoints."""
 from .apirequest import APIRequest
+from ..exceptions import StreamTerminated
 from .decorators import dyndoc_insert, endpoint, abstractclass, extendargs
 from .definitions.transactions import definitions    # flake8: noqa
+from types import GeneratorType
 
 responses = {
     "_v3_accounts_accountID_transactions": {
@@ -140,3 +142,9 @@ class TransactionsStream(Transactions):
     """
 
     STREAM = True
+
+    def terminate(self, message=""):
+        if not isinstance(self.response, GeneratorType):
+            raise ValueError("request does not contain a stream response")
+
+        self.response.throw(StreamTerminated(message))

--- a/oandapyV20/exceptions.py
+++ b/oandapyV20/exceptions.py
@@ -1,6 +1,10 @@
 """Exceptions."""
 
 
+class StreamTerminated(Exception):
+    """StreamTerminated."""
+
+
 class V20Error(Exception):
     """Generic error class.
 


### PR DESCRIPTION
the API class kept state for the streaming requests. This state is now kept
in the request itself.
Termination of the stream is now done by the terminate() method of the
streaming request class, which raises a StreamTerminated exception
Example and tests modified to reflect the modifications