### PR TITLE
Refact endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 - "pypy"
 install:
 - pip install pip --upgrade
+- pip install six
 - pip install requests-mock
 - pip install coveralls
 - pip install nose nose-parameterized

--- a/oandapyV20/endpoints/accounts.py
+++ b/oandapyV20/endpoints/accounts.py
@@ -1,18 +1,21 @@
 # -*- encoding: utf-8 -*-
 """Handle account endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass
+from .decorators import dyndoc_insert, endpoint
 from .definitions.accounts import definitions    # flake8: noqa
 from .responses.accounts import responses
+from abc import ABCMeta, abstractmethod
 
 
-@abstractclass
 class Accounts(APIRequest):
     """Accounts - class to handle the accounts endpoints."""
+
+    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"
 
+    @abstractmethod
     @dyndoc_insert(responses)
     def __init__(self, accountID=None):
         """Instantiate an Accounts APIRequest instance.

--- a/oandapyV20/endpoints/accounts.py
+++ b/oandapyV20/endpoints/accounts.py
@@ -4,13 +4,11 @@ from .apirequest import APIRequest
 from .decorators import dyndoc_insert, endpoint
 from .definitions.accounts import definitions    # flake8: noqa
 from .responses.accounts import responses
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 
 class Accounts(APIRequest):
     """Accounts - class to handle the accounts endpoints."""
-
-    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"

--- a/oandapyV20/endpoints/apirequest.py
+++ b/oandapyV20/endpoints/apirequest.py
@@ -1,11 +1,10 @@
 """Handling of API requests."""
+import six
 from abc import ABCMeta, abstractmethod
 
-
+@six.add_metaclass(ABCMeta)
 class APIRequest(object):
     """Base Class for API-request classes."""
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def __init__(self, endpoint, method="GET", expected_status=200):

--- a/oandapyV20/endpoints/apirequest.py
+++ b/oandapyV20/endpoints/apirequest.py
@@ -18,10 +18,6 @@ class APIRequest(object):
 
         method : string
             the method for the request. Default: GET.
-
-        body : dict
-            dictionary with data for the request. This data
-            will be sent as JSON-data.
         """
         self._expected_status = expected_status
         self._status_code = None

--- a/oandapyV20/endpoints/instruments.py
+++ b/oandapyV20/endpoints/instruments.py
@@ -1,18 +1,21 @@
 # -*- encoding: utf-8 -*-
 """Handle instruments endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass
+from .decorators import dyndoc_insert, endpoint
 from .definitions.instruments import definitions    # flake8: noqa
 from .responses.instruments import responses
+from abc import ABCMeta, abstractmethod
 
 
-@abstractclass
 class Instruments(APIRequest):
     """Instruments - abstract class to handle instruments endpoint."""
+
+    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"
 
+    @abstractmethod
     @dyndoc_insert(responses)
     def __init__(self, instrument):
         """Instantiate a Instrument APIRequest instance.

--- a/oandapyV20/endpoints/instruments.py
+++ b/oandapyV20/endpoints/instruments.py
@@ -4,13 +4,11 @@ from .apirequest import APIRequest
 from .decorators import dyndoc_insert, endpoint
 from .definitions.instruments import definitions    # flake8: noqa
 from .responses.instruments import responses
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 
 class Instruments(APIRequest):
     """Instruments - abstract class to handle instruments endpoint."""
-
-    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"

--- a/oandapyV20/endpoints/orders.py
+++ b/oandapyV20/endpoints/orders.py
@@ -1,19 +1,22 @@
 # -*- encoding: utf-8 -*-
 """Handle orders and pendingOrders endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass
+from .decorators import dyndoc_insert, endpoint
 from .definitions.orders import definitions    # flake8: noqa
 from .responses.orders import responses
+from abc import ABCMeta, abstractmethod
 
 
-@abstractclass
 class Orders(APIRequest):
     """Orders - abstract base class to handle the orders endpoints."""
+
+    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"
     EXPECTED_STATUS = 0
 
+    @abstractmethod
     @dyndoc_insert(responses)
     def __init__(self, accountID, orderID=None):
         """Instantiate an Orders request.

--- a/oandapyV20/endpoints/orders.py
+++ b/oandapyV20/endpoints/orders.py
@@ -4,13 +4,11 @@ from .apirequest import APIRequest
 from .decorators import dyndoc_insert, endpoint
 from .definitions.orders import definitions    # flake8: noqa
 from .responses.orders import responses
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 
 class Orders(APIRequest):
     """Orders - abstract base class to handle the orders endpoints."""
-
-    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"

--- a/oandapyV20/endpoints/positions.py
+++ b/oandapyV20/endpoints/positions.py
@@ -1,16 +1,19 @@
 """Handle position endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass
+from .decorators import dyndoc_insert, endpoint
 from .responses.positions import responses
+from abc import ABCMeta, abstractmethod
 
 
-@abstractclass
 class Positions(APIRequest):
     """Positions - abstractbase class to handle the 'positions' endpoints."""
+
+    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"
 
+    @abstractmethod
     @dyndoc_insert(responses)
     def __init__(self, accountID, instrument=None):
         """Instantiate a Positions APIRequest instance.

--- a/oandapyV20/endpoints/positions.py
+++ b/oandapyV20/endpoints/positions.py
@@ -2,13 +2,11 @@
 from .apirequest import APIRequest
 from .decorators import dyndoc_insert, endpoint
 from .responses.positions import responses
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 
 class Positions(APIRequest):
     """Positions - abstractbase class to handle the 'positions' endpoints."""
-
-    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"

--- a/oandapyV20/endpoints/pricing.py
+++ b/oandapyV20/endpoints/pricing.py
@@ -2,19 +2,22 @@
 """Handle pricing endpoints."""
 from .apirequest import APIRequest
 from ..exceptions import StreamTerminated
-from .decorators import dyndoc_insert, endpoint, abstractclass
+from .decorators import dyndoc_insert, endpoint
 from .definitions.pricing import definitions    # flake8: noqa
 from .responses.pricing import responses
 from types import GeneratorType
+from abc import ABCMeta, abstractmethod
 
 
-@abstractclass
 class Pricing(APIRequest):
     """Pricing - class to handle pricing endpoint."""
+
+    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"
 
+    @abstractmethod
     def __init__(self, accountID):
         """Instantiate a Pricing APIRequest instance.
 

--- a/oandapyV20/endpoints/pricing.py
+++ b/oandapyV20/endpoints/pricing.py
@@ -6,13 +6,11 @@ from .decorators import dyndoc_insert, endpoint
 from .definitions.pricing import definitions    # flake8: noqa
 from .responses.pricing import responses
 from types import GeneratorType
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 
 class Pricing(APIRequest):
     """Pricing - class to handle pricing endpoint."""
-
-    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"

--- a/oandapyV20/endpoints/trades.py
+++ b/oandapyV20/endpoints/trades.py
@@ -4,13 +4,11 @@ from .apirequest import APIRequest
 from .decorators import dyndoc_insert, endpoint
 from .definitions.trades import definitions    # flake8: noqa
 from .responses.trades import responses
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 
 class Trades(APIRequest):
     """Trades - abstract baseclass to handle the trades endpoints."""
-
-    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"

--- a/oandapyV20/endpoints/trades.py
+++ b/oandapyV20/endpoints/trades.py
@@ -1,18 +1,21 @@
 # -*- encoding: utf-8 -*-
 """Handle trades endpoints."""
 from .apirequest import APIRequest
-from .decorators import dyndoc_insert, endpoint, abstractclass
+from .decorators import dyndoc_insert, endpoint
 from .definitions.trades import definitions    # flake8: noqa
 from .responses.trades import responses
+from abc import ABCMeta, abstractmethod
 
 
-@abstractclass
 class Trades(APIRequest):
     """Trades - abstract baseclass to handle the trades endpoints."""
+
+    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"
 
+    @abstractmethod
     @dyndoc_insert(responses)
     def __init__(self, accountID, tradeID=None):
         """Instantiate a Trades APIRequest instance.

--- a/oandapyV20/endpoints/transactions.py
+++ b/oandapyV20/endpoints/transactions.py
@@ -2,19 +2,22 @@
 """Handle transactions endpoints."""
 from .apirequest import APIRequest
 from ..exceptions import StreamTerminated
-from .decorators import dyndoc_insert, endpoint, abstractclass
+from .decorators import dyndoc_insert, endpoint
 from .definitions.transactions import definitions    # flake8: noqa
 from .responses.transactions import responses
 from types import GeneratorType
+from abc import ABCMeta, abstractmethod
 
 
-@abstractclass
 class Transactions(APIRequest):
     """Transactions - abstract baseclass to handle transaction endpoints."""
+
+    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"
 
+    @abstractmethod
     @dyndoc_insert(responses)
     def __init__(self, accountID, transactionID=None):
         """Instantiate a Transactions APIRequest instance.

--- a/oandapyV20/endpoints/transactions.py
+++ b/oandapyV20/endpoints/transactions.py
@@ -6,13 +6,11 @@ from .decorators import dyndoc_insert, endpoint
 from .definitions.transactions import definitions    # flake8: noqa
 from .responses.transactions import responses
 from types import GeneratorType
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 
 class Transactions(APIRequest):
     """Transactions - abstract baseclass to handle transaction endpoints."""
-
-    __metaclass__ = ABCMeta
 
     ENDPOINT = ""
     METHOD = "GET"

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,5 +1,7 @@
 import unittest
-from oandapyV20.endpoints.decorators import extendargs
+from oandapyV20.endpoints.decorators import extendargs, abstractclass
+from abc import ABCMeta, abstractmethod
+import six
 
 
 class TestDecorators(unittest.TestCase):
@@ -19,6 +21,44 @@ class TestDecorators(unittest.TestCase):
 
         tst = SomethingExtra(x=10, y=20)
         self.assertEqual(tst.add(), 30)
+
+
+    def test__abstractclass(self):
+
+        @six.add_metaclass(ABCMeta)
+        class Something(object):
+
+            @abstractmethod
+            def __init__(self, x=10):
+                 self.x = x
+
+        @abstractclass
+        class SomethingElse(Something):
+            # derived classes from this class make use
+            # of this class __init__
+            # since this __init__ overrides the parent's
+            # @abstractmethod instances could be created,
+            # by making the class abstract with @abstractclass
+            # this can't be done, derived classes can
+            # ... that is the goal
+
+            def __init__(self, x=10, y=20):
+                super(SomethingElse, self).__init__(x)
+                self.y = y
+
+        class ABCDerived(SomethingElse):
+            pass
+
+        with self.assertRaises(TypeError) as errAbstract:
+            smth = Something(x=20)
+        with self.assertRaises(TypeError) as errAbstractBase: 
+            smthelse = SomethingElse(x=20, y=30)
+
+        x = 20
+        y = 30
+        abcDerived = ABCDerived(x, y)
+        self.assertEqual(abcDerived.x + abcDerived.y, x+y)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -57,7 +57,8 @@ class TestOrders(unittest.TestCase):
             r = orders.Orders(accountID)
 
         bcErr = bcErr.exception
-        self.assertTrue("Use of abstract base class" in "{}".format(bcErr))
+        self.assertTrue("Can't instantiate abstract class Orders "
+                        "with abstract methods" in "{}".format(bcErr))
 
     @requests_mock.Mocker()
     def test__order_create(self, mock_post):

--- a/tests/test_trades.py
+++ b/tests/test_trades.py
@@ -55,7 +55,8 @@ class TestTrades(unittest.TestCase):
             r = trades.Trades(accountID)
 
         bcErr = bcErr.exception
-        self.assertTrue("Use of abstract base class" in "{}".format(bcErr))
+        self.assertTrue("Can't instantiate abstract class Trades "
+                        "with abstract methods" in "{}".format(bcErr))
 
     @requests_mock.Mocker()
     def test__trades_list(self, mock_get):


### PR DESCRIPTION
- [x] abstractclass decorator removed from the abstract request classes. Since each derived request class now has it's own `__init__` the standard _abc module_  can be applied
- [x] six module added to support ABC code for both python 2.7 and 3.x versions
