### PR TITLE
Make use of the json of requests

### DIFF
--- a/oandapyV20/oandapyV20.py
+++ b/oandapyV20/oandapyV20.py
@@ -289,7 +289,7 @@ class API(object):
         if method == 'get':
             request_args['params'] = params
         elif hasattr(endpoint, "data") and endpoint.data:
-            request_args['data'] = json.dumps(endpoint.data)
+            request_args['json'] = endpoint.data
 
         # if any parameter for request then merge them
         request_args.update(self._request_params)


### PR DESCRIPTION
requests provides a json parameter for PUT/PATCH/POST
this is the preferred usage instead of doing the JSON conversion and passing it via the data parameter