### PR TITLE
Fixed TradesList.params bug

### DIFF
--- a/oandapyV20/endpoints/trades.py
+++ b/oandapyV20/endpoints/trades.py
@@ -66,6 +66,7 @@ class TradesList(Trades):
 
         """
         super(TradesList, self).__init__(accountID)
+        self.params = params
 
 
 @endpoint("v3/accounts/{accountID}/openTrades")


### PR DESCRIPTION
Fixes a bug in trades.TradesList class where `params` argument of `__init__` class wasn't getting assigned.