### PR TITLE
Health API

### DIFF
--- a/oandapyV20/contrib/healthAPI.py
+++ b/oandapyV20/contrib/healthAPI.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Handle instruments endpoints."""
+from oandapyV20.endpoints.apirequest import APIRequest
+from oandapyV20.endpoints.decorators import endpoint
+
+
+@endpoint("api/v1/services")
+class Services(APIRequest):
+    """Get a list of services."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self):
+        """Instantiate a Services request."""
+        endpoint = self.ENDPOINT
+        super(Services, self).__init__(endpoint, method=self.METHOD)
+
+
+@endpoint("api/v1/services/{serviceID}")
+class ServiceByID(APIRequest):
+    """Get a list of services."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self, serviceID):
+        """Instantiate a Service request."""
+        endpoint = self.ENDPOINT.format(serviceID=serviceID)
+        super(ServiceByID, self).__init__(endpoint, method=self.METHOD)
+
+
+@endpoint("api/v1/service-lists")
+class ServiceLists(APIRequest):
+    """Get a list of service lists."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self):
+        """Instantiate a ServiceList request."""
+        endpoint = self.ENDPOINT
+        super(ServiceLists, self).__init__(endpoint, method=self.METHOD)
+
+
+@endpoint("api/v1/services-lists/{serviceListID}")
+class ServiceListByID(APIRequest):
+    """Get a single service list."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self, serviceListID):
+        """Instantiate a ServiceList request."""
+        endpoint = self.ENDPOINT.format(serviceListID=serviceListID)
+        super(ServiceListByID, self).__init__(endpoint, method=self.METHOD)
+
+
+@endpoint("api/v1/services/{serviceID}/events")
+class ServiceEventsList(APIRequest):
+    """Get a list of events for a service."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self, serviceID, params=None):
+        """Instantiate an EventsList request."""
+        endpoint = self.ENDPOINT.format(serviceID=serviceID)
+        super(ServiceEventsList, self).__init__(endpoint, method=self.METHOD)
+        self.params = params
+
+
+@endpoint("api/v1/services/{serviceID}/events/current")
+class ServiceEventCurrent(APIRequest):
+    """Get a list of events for a service."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self, serviceID):
+        """Instantiate an EventsList request."""
+        endpoint = self.ENDPOINT.format(serviceID=serviceID)
+        super(ServiceEventCurrent, self).__init__(endpoint, method=self.METHOD)
+
+
+@endpoint("api/v1/services/{serviceID}/events/{eventID}")
+class ServiceEventByID(APIRequest):
+    """Get a service event by ID."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self, serviceID, eventID):
+        """Instantiate an EventsList request."""
+        endpoint = self.ENDPOINT.format(serviceID=serviceID, eventID=eventID)
+        super(ServiceEventByID, self).__init__(endpoint, method=self.METHOD)
+
+
+@endpoint("api/v1/statuses")
+class Statuses(APIRequest):
+    """Get a list of all statuses."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self):
+        """Instantiate a Statuses request."""
+        endpoint = self.ENDPOINT
+        super(Statuses, self).__init__(endpoint, method=self.METHOD)
+
+
+@endpoint("api/v1/statuses/{statusID}")
+class StatusByID(APIRequest):
+    """Get a status by ID."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self, statusID):
+        """Instantiate a StatusByID request."""
+        endpoint = self.ENDPOINT.format(statusID=statusID)
+        super(StatusByID, self).__init__(endpoint, method=self.METHOD)
+
+
+@endpoint("api/v1/status-images")
+class StatusImages(APIRequest):
+    """Get a all status images."""
+    ENDPOINT = ""
+    METHOD = "GET"
+
+    def __init__(self):
+        """Instantiate a StatusImages request."""
+        endpoint = self.ENDPOINT
+        super(StatusImages, self).__init__(endpoint, method=self.METHOD)


### PR DESCRIPTION
Provide support to the health-API endpoints.

In case of exceptions on the REST-V1 / REST-V20 this API can (possibly) provide extra information regarding the status of the services.

```python
import sys
import json
import oandapyV20
from oandapyV20.exceptions import V20Error
import oandapyV20.contrib.healthAPI as health

# for time being: add health URL's to available environments
setattr(sys.modules["oandapyV20.oandapyV20"],
                   "TRADING_ENVIRONMENTS",
                    {"health": {
                     "stream": "http://api-status.oanda.com",
                     "api": "http://api-status.oanda.com",
                     }})


api = oandapyV20.API(access_token=None, environment="health")

r = health.Services()
print("REQ: {}".format(r))
try:
    api.request(r)

except Exception as err:
    print("Pretty bad! health service not accessible")
    exit(2)

else:
    print("{}".format(json.dumps(r.response, indent=2)))
    print("# services: ", len(r.response['services']))
    # show some info
    for service in r.response['services']:
        print('ID  : {}'.format(service['id']))
        print('DESC: {}'.format(service['name']))
        print('ST: {}'.format(service.get('current-event').get('status').get('description')))
```
