### PR TITLE
Candlefactory firstrec fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+Version 0.4.5
+-------------
+
+2017/09/25
+          force 'includeFirst' in InstrumentsCandlesFactory, #100
+
 Version 0.4.4
 -------------
 

--- a/oandapyV20/__init__.py
+++ b/oandapyV20/__init__.py
@@ -3,7 +3,7 @@ from .oandapyV20 import API
 from .exceptions import V20Error
 
 __title__ = "OANDA REST V20 API Wrapper"
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 __author__ = "Feite Brekeveld"
 __license__ = "MIT"
 __copyright__ = "Copyright 2016 - 2017 Feite Brekeveld"

--- a/oandapyV20/contrib/factories/history.py
+++ b/oandapyV20/contrib/factories/history.py
@@ -27,6 +27,9 @@ def InstrumentsCandlesFactory(instrument, params=None):
     The *count* parameter is only used to control the number of records to
     retrieve in a single request.
 
+    The *includeFirst* parameter is forced to make sure that results do
+    no have a 1-record gap between consecutive requests.
+
     Parameters
     ----------
 
@@ -114,6 +117,8 @@ def InstrumentsCandlesFactory(instrument, params=None):
         for k in ['count', 'from', 'to']:
             if k in cpparams:
                 del cpparams[k]
+        # force includeFirst
+        cpparams.update({"includeFirst": True})
 
         # generate InstrumentsCandles requests for all 'bars', each request
         # requesting max. count records
@@ -126,4 +131,4 @@ def InstrumentsCandlesFactory(instrument, params=None):
             yparams.update({"to": secs2time(to).strftime(RFC3339)})
             yield instruments.InstrumentsCandles(instrument=instrument,
                                                  params=yparams)
-            _epoch_from = to + gs  # advance 1 record
+            _epoch_from = to


### PR DESCRIPTION
force use of *includeFirst* in generated requests, see #100 