### PR TITLE
support the 'distance' parameter

### DIFF
--- a/oandapyV20/contrib/requests/onfill.py
+++ b/oandapyV20/contrib/requests/onfill.py
@@ -129,7 +129,8 @@ class StopLossDetails(OnFill):
     """
 
     def __init__(self,
-                 price,
+                 price=None,
+                 distance=None,
                  timeInForce=OD.TimeInForce.GTC,
                  gtdTime=None,
                  clientExtensions=None):
@@ -138,8 +139,11 @@ class StopLossDetails(OnFill):
         Parameters
         ----------
 
-        price : float or string (required)
+        price : float or string (either price or distance is required)
             the price to trigger take profit order
+
+        distance : float or string (either price or distance is required)
+            the distance to trigger take profit order
 
         timeInForce : TimeInForce (required), default TimeInForce.GTC
             the time in force
@@ -185,7 +189,18 @@ class StopLossDetails(OnFill):
             timeInForce=timeInForce,
             gtdTime=gtdTime,
             clientExtensions=clientExtensions)
-        self._data.update({"price": PriceValue(price).value})
+
+        if price is not None and distance is not None:
+            raise ValueError("price or distance is required")
+
+        if price is not None:
+            self._data.update({"price": PriceValue(price).value})
+
+        elif distance is not None:
+            self._data.update({"distance": PriceValue(distance).value})
+
+        else:
+            raise ValueError("price or distance is required")
 
 
 class TrailingStopLossDetails(OnFill):

--- a/oandapyV20/contrib/requests/stoplossorder.py
+++ b/oandapyV20/contrib/requests/stoplossorder.py
@@ -14,7 +14,8 @@ class StopLossOrderRequest(BaseRequest):
 
     def __init__(self,
                  tradeID,
-                 price,
+                 price=None,
+                 distance=None,
                  clientTradeID=None,
                  timeInForce=TimeInForce.GTC,
                  gtdTime=None,
@@ -71,7 +72,18 @@ class StopLossOrderRequest(BaseRequest):
 
         # required
         self._data.update({"tradeID": TradeID(tradeID).value})
-        self._data.update({"price": PriceValue(price).value})
+
+        if price is not None and distance is not None:
+            raise ValueError("price or distance is required")
+
+        if price is not None:
+            self._data.update({"price": PriceValue(price).value})
+
+        elif distance is not None:
+            self._data.update({"distance": str(distance)})
+
+        else:
+            raise ValueError("price or distance is required")
 
         # optional
         self._data.update({"clientExtensions": clientExtensions})

--- a/tests/test_contrib_orders.py
+++ b/tests/test_contrib_orders.py
@@ -170,6 +170,33 @@ class TestContribRequests(unittest.TestCase):
             'type': 'STOP_LOSS'},
            ValueError
         ),
+       # SLO: distance instead of price
+       (req.StopLossOrderRequest,
+           {"tradeID": "1234",
+            "timeInForce": "GTC",
+            "distance": 50},
+           {'timeInForce': 'GTC',
+            'type': 'STOP_LOSS',
+            'distance': '50'},
+        ),
+       # ... no price and no distance, should raise a ValueError
+       (req.StopLossOrderRequest,
+           {"tradeID": "1234"},
+           {'timeInForce': 'GTC',
+            'type': 'STOP_LOSS'},
+           ValueError
+        ),
+       # ... price and distance, should raise a ValueError
+       (req.StopLossOrderRequest,
+           {"tradeID": "1234",
+            "price": 1.10,
+            "distance": 40},
+           {'timeInForce': 'GTC',
+            'price': 1.10,
+            'distance': 40,
+            'type': 'STOP_LOSS'},
+           ValueError
+        ),
        # ... FOK, should raise a ValueError
        (req.StopLossOrderRequest,
            {"tradeID": "1234",
@@ -239,6 +266,9 @@ class TestContribRequests(unittest.TestCase):
 
         if not exc:
             r = cls(**inpar)
+            print("*************")
+            print(r.data)
+            print(refpar)
             self.assertTrue(r.data == reference)
         else:
             with self.assertRaises(exc):
@@ -318,6 +348,27 @@ class TestContribRequests(unittest.TestCase):
            {'timeInForce': 'GTC',
             'price': '1.10000'}
         ),
+       # ... distance instead of price
+       (req.StopLossDetails,
+           {"distance": 40},
+           {'timeInForce': 'GTC',
+            'distance': '40.00000'}
+        ),
+       # .. raises ValueError because price and distance
+       (req.StopLossDetails,
+           {"distance": 40,
+            "price": 1.10},
+           {'timeInForce': 'GTC',
+            'price': '1.10000',
+            'distance': '40.00000'},
+           ValueError
+        ),
+       # .. raises ValueError because no price and no distance
+       (req.StopLossDetails,
+           {"timeInForce": OD.TimeInForce.GTC},
+           {'timeInForce': 'GTC'},
+           ValueError
+        ),
        # .. raises ValueError because GTD required gtdTime
        (req.StopLossDetails,
            {"price": 1.10,
@@ -380,6 +431,9 @@ class TestContribRequests(unittest.TestCase):
 
         if not exc:
             r = cls(**inpar) if inpar else cls()
+            print("*************")
+            print(r.data)
+            print(refpar)
             self.assertTrue(r.data == refpar)
         else:
             with self.assertRaises(exc):


### PR DESCRIPTION
Regarding #145 : Missing `distance` parameter on `StopLossOrderRequest` and  `StopLossDetails` implemented

OANDA docs are not 100% clear about where the parameter is supported. The TakeProfitOrderRequest names `distance` in it's header but in the details nothing is found. Placing a TP-order using `distance` fails with an error. 

I raised a question at OANDA regarding this: docs wrong or is it not implemented (yet)?

2019-07-17: update from OANDA: they are looking into this ... 

2019-07-29: update from OANDA: _this parameter is not public yet and may contain bugs. So it is not recommended to be used by any script or third-party application._

Bottomline: it can't be used in a TakeProfitOrderRequest !