### PR TITLE
Added __enter__ and __exit__ methods to oandapyV20

### DIFF
--- a/oandapyV20/oandapyV20.py
+++ b/oandapyV20/oandapyV20.py
@@ -210,6 +210,12 @@ class API(object):
             self.client.headers.update(headers)
             logger.info("applying headers %s", ",".join(headers.keys()))
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.client.close()
+
     @property
     def request_params(self):
         """request_params property."""

--- a/oandapyV20/oandapyV20.py
+++ b/oandapyV20/oandapyV20.py
@@ -222,7 +222,7 @@ class API(object):
         explicit close of the session.
         """
         self.client.close()
-        
+
     @property
     def request_params(self):
         """request_params property."""

--- a/oandapyV20/oandapyV20.py
+++ b/oandapyV20/oandapyV20.py
@@ -214,8 +214,15 @@ class API(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.client.close()
+        self.close()
 
+    def close(self):
+        """close.
+        
+        explicit close of the session.
+        """
+        self.client.close()
+        
     @property
     def request_params(self):
         """request_params property."""

--- a/oandapyV20/oandapyV20.py
+++ b/oandapyV20/oandapyV20.py
@@ -218,7 +218,7 @@ class API(object):
 
     def close(self):
         """close.
-        
+
         explicit close of the session.
         """
         self.client.close()


### PR DESCRIPTION
Support `with` statement from PEP343
Close requests.Session on __exit__

The unclosed requests.Session was throwing an unclosed socket in my unit tests.  Similar findings were found in https://stackoverflow.com/questions/48160728/resourcewarning-unclosed-socket-in-python-3-unit-test
The stackoverflow link shows some other suitable workarounds.

```
with API(access_token=access_token, environment=env) as client:
    r = trades.TradesList(accountID)
    rv = client.request(r)
    print("RESPONSE:\n{}".format(json.dumps(rv, indent=2)))
```