### PR TITLE
Update types.py

### DIFF
--- a/oandapyV20/types/types.py
+++ b/oandapyV20/types/types.py
@@ -184,10 +184,10 @@ class PriceValue(OAType):
 
 
 class Units(OAType):
-    """representation Units, string value of an integer."""
+    """representation Units, string value of a float."""
 
     def __init__(self, units):
-        self._v = "{:d}".format(int(units))
+        self._v = "{:f}".format(float(units))
 
 
 class ClientID(OAType):


### PR DESCRIPTION
Units (Trade/Order Units) can be a float with decimal points up to the precision given by the Oanda Instrument. Floats with a higher precision, more decimal spaces, gives error UNITS_PRECISION_EXCEEDED. New index changes in Oanda allow trades from 0.1 lots with a precision of 1 (one decimal place)